### PR TITLE
fix: use publishService.enabled instead of extraArgs

### DIFF
--- a/apps/stable/nginx-ingress/values.yaml.gotmpl
+++ b/apps/stable/nginx-ingress/values.yaml.gotmpl
@@ -1,7 +1,7 @@
 controller:
   replicaCount: 3
-  extraArgs:
-    publish-service: nginx/nginx-ingress-controller
+  publishService:
+    enabled: true
   service:
     omitClusterIP: true
   {{- if eq .Values.jxRequirements.cluster.provider "kind" }}


### PR DESCRIPTION
The extraArgs approach is more "hard-coded"