### PR TITLE
fix(charts/bucketrepo): use storage repository URL from jx-requirements if available

### DIFF
--- a/charts/jenkins-x/bucketrepo/secret-schema.yaml
+++ b/charts/jenkins-x/bucketrepo/secret-schema.yaml
@@ -27,8 +27,14 @@ spec:
             username: "{{ secret "jenkins-x-bucketrepo" "username" }}"
             password: "{{ secret "jenkins-x-bucketrepo" "password" }}"
             chartPath: "charts"
+        {{- if and (hasKey .Requirements.storage "repository") (eq .Requirements.storage.repository.enabled true) }}
+        storage:
+            enabled: true
+            bucket_url: "{{ .Requirements.storage.repository.url }}"
+        {{- else }}
         storage:
             bucket_url: ""
+        {{- end }}
         cache:
             base_dir: "/tmp/bucketrepo"
         repositories:
@@ -43,5 +49,4 @@ spec:
             - url: "https://repo.spring.io/milestone/"
             - url: "https://repo.spring.io/release/"
             - url: "http://uk.maven.org/maven2/"
-
 


### PR DESCRIPTION
This PR populates the bucket URL in bucketrepo's secret-schema.yaml if the corresponding key was set in jx-requirements.yaml, keeping the previous behaviour of using local storage if it was not set