### PR TITLE
fix: tekton use gitUrl from jxRequirements

### DIFF
--- a/charts/jenkins-x/jxboot-helmfile-resources/values.yaml.gotmpl
+++ b/charts/jenkins-x/jxboot-helmfile-resources/values.yaml.gotmpl
@@ -4,6 +4,9 @@ versions:
 sourceRepositoriesEnvKey: true
 
 pipeline:
+  auth:
+    git:
+      url: {{ .Values.jxRequirements.cluster.gitServer | default "https://github.com" }}
   serviceAccount:
 {{- if and (hasKey .Values.jxRequirements.cluster "project") (hasKey .Values.jxRequirements.cluster "clusterName") (eq .Values.jxRequirements.cluster.provider "eks") }}
     annotations:


### PR DESCRIPTION
default tekton to use the same gitUrl for the main jenkins-x repo https://github.com/jenkins-x-charts/jxboot-helmfile-resources/blob/618c8e89e741c8a5e2f54dd8755fa3bceca1e7a8/jxboot-helmfile-resources/templates/tekton-git-secret.yaml#L10