### PR TITLE
fix: lock down jx-pipelines-visualizer & jx-kh-check versions

### DIFF
--- a/charts/jx3/health-checks-install/defaults.yaml
+++ b/charts/jx3/health-checks-install/defaults.yaml
@@ -1,1 +1,3 @@
+gitUrl: https://github.com/jenkins-x-plugins/jx-kh-check
+version: 0.0.32
 namespace: jx-git-operator

--- a/charts/jx3/health-checks-jx/defaults.yaml
+++ b/charts/jx3/health-checks-jx/defaults.yaml
@@ -1,1 +1,3 @@
+gitUrl: https://github.com/jenkins-x-plugins/jx-kh-check
+version: 0.0.32
 namespace: jx

--- a/charts/jx3/jx-kh-check/defaults.yaml
+++ b/charts/jx3/jx-kh-check/defaults.yaml
@@ -1,1 +1,3 @@
+gitUrl: https://github.com/jenkins-x-plugins/jx-kh-check
+version: 0.0.32
 namespace: kuberhealthy

--- a/charts/jx3/jx-pipelines-visualizer/defaults.yaml
+++ b/charts/jx3/jx-pipelines-visualizer/defaults.yaml
@@ -1,2 +1,2 @@
 gitUrl: https://github.com/jenkins-x/jx-pipelines-visualizer
-version: 0.0.43
+version: 0.0.44

--- a/charts/jx3/jx-pipelines-visualizer/defaults.yaml
+++ b/charts/jx3/jx-pipelines-visualizer/defaults.yaml
@@ -1,0 +1,2 @@
+gitUrl: https://github.com/jenkins-x/jx-pipelines-visualizer
+version: 0.0.43


### PR DESCRIPTION
See https://kubernetes.slack.com/archives/C9MBGQJRH/p1602842034264800\?thread_ts\=1602763034.179300\&cid\=C9MBGQJRH for context