### PR TITLE
fix: lets clone via: jx gitops git clone

### DIFF
--- a/git-operator/job-gsm.yaml
+++ b/git-operator/job-gsm.yaml
@@ -16,46 +16,15 @@ spec:
     spec:
       initContainers:
       - args:
-        - '-c'
-        - 'mkdir -p $HOME; git config --global --add user.name $GIT_AUTHOR_NAME; git
-          config --global --add user.email $GIT_AUTHOR_EMAIL; git config --global
-          credential.helper store; git clone https://${GIT_USER}:${GIT_TOKEN}@${GIT_URL#"https://"} ${GIT_SUB_DIR}; echo cloned
-          url: $(inputs.params.url) to dir: ${GIT_SUB_DIR}; cd ${GIT_SUB_DIR}; git
-          checkout ${GIT_REVISION}; echo checked out revision: ${GIT_REVISION} to
-          dir: ${GIT_SUB_DIR}'
+        - gitops
+        - git
+        - clone
         command:
-        - /bin/sh
+        - jx
         env:
-        - name: GIT_URL
-          valueFrom:
-            secretKeyRef:
-              key: url
-              name: jx-boot
-        - name: GIT_USER
-          valueFrom:
-            secretKeyRef:
-              key: username
-              name: jx-boot
-        - name: GIT_TOKEN
-          valueFrom:
-            secretKeyRef:
-              key: password
-              name: jx-boot
-        - name: GIT_REVISION
-          value: master
-        - name: GIT_SUB_DIR
-          value: source
-        - name: GIT_AUTHOR_EMAIL
-          value: jenkins-x@googlegroups.com
-        - name: GIT_AUTHOR_NAME
-          value: jenkins-x-labs-bot
-        - name: GIT_COMMITTER_EMAIL
-          value: jenkins-x@googlegroups.com
-        - name: GIT_COMMITTER_NAME
-          value: jenkins-x-labs-bot
         - name: XDG_CONFIG_HOME
           value: /workspace/xdg_config
-        image: gcr.io/jenkinsxio/jx-boot:3.0.734
+        image: gcr.io/jenkinsxio/jx-boot:3.0.754
         name: git-clone
         volumeMounts:
         - mountPath: /workspace
@@ -68,6 +37,8 @@ spec:
         - /bin/sh
         - -c
         env:
+        - name: XDG_CONFIG_HOME
+          value: /workspace/xdg_config
         - name: JX_SECRET_SIDECAR
           value: gsm
         - name: JX_SECRET_TMP_DIR

--- a/git-operator/job-vault.yaml
+++ b/git-operator/job-vault.yaml
@@ -16,46 +16,15 @@ spec:
     spec:
       initContainers:
       - args:
-        - '-c'
-        - 'mkdir -p $HOME; git config --global --add user.name $GIT_AUTHOR_NAME; git
-          config --global --add user.email $GIT_AUTHOR_EMAIL; git config --global
-          credential.helper store; git clone https://${GIT_USER}:${GIT_TOKEN}@${GIT_URL#"https://"} ${GIT_SUB_DIR}; echo cloned
-          url: $(inputs.params.url) to dir: ${GIT_SUB_DIR}; cd ${GIT_SUB_DIR}; git
-          checkout ${GIT_REVISION}; echo checked out revision: ${GIT_REVISION} to
-          dir: ${GIT_SUB_DIR}'
+        - gitops
+        - git
+        - clone
         command:
-        - /bin/sh
+        - jx
         env:
-        - name: GIT_URL
-          valueFrom:
-            secretKeyRef:
-              key: url
-              name: jx-boot
-        - name: GIT_USER
-          valueFrom:
-            secretKeyRef:
-              key: username
-              name: jx-boot
-        - name: GIT_TOKEN
-          valueFrom:
-            secretKeyRef:
-              key: password
-              name: jx-boot
-        - name: GIT_REVISION
-          value: master
-        - name: GIT_SUB_DIR
-          value: source
-        - name: GIT_AUTHOR_EMAIL
-          value: jenkins-x@googlegroups.com
-        - name: GIT_AUTHOR_NAME
-          value: jenkins-x-labs-bot
-        - name: GIT_COMMITTER_EMAIL
-          value: jenkins-x@googlegroups.com
-        - name: GIT_COMMITTER_NAME
-          value: jenkins-x-labs-bot
         - name: XDG_CONFIG_HOME
           value: /workspace/xdg_config
-        image: gcr.io/jenkinsxio/jx-boot:3.0.734
+        image: gcr.io/jenkinsxio/jx-boot:3.0.754
         name: git-clone
         volumeMounts:
         - mountPath: /workspace
@@ -66,6 +35,9 @@ spec:
         - apply
         command:
         - make
+        env:
+        - name: XDG_CONFIG_HOME
+          value: /workspace/xdg_config
         image: gcr.io/jenkinsxio/jx-boot:3.0.734
         imagePullPolicy: Always
         name: job

--- a/git-operator/job.yaml
+++ b/git-operator/job.yaml
@@ -16,45 +16,11 @@ spec:
     spec:
       initContainers:
       - args:
-        - '-c'
-        - 'mkdir -p $HOME; git config --global --add user.name $GIT_AUTHOR_NAME; git
-          config --global --add user.email $GIT_AUTHOR_EMAIL; git config --global
-          credential.helper store; git clone https://${GIT_USER}:${GIT_TOKEN}@${GIT_URL#"https://"} ${GIT_SUB_DIR}; echo cloned
-          url: $(inputs.params.url) to dir: ${GIT_SUB_DIR}; cd ${GIT_SUB_DIR}; git
-          checkout ${GIT_REVISION}; echo checked out revision: ${GIT_REVISION} to
-          dir: ${GIT_SUB_DIR}'
+        - gitops
+        - git
+        - clone
         command:
-        - /bin/sh
-        env:
-        - name: GIT_URL
-          valueFrom:
-            secretKeyRef:
-              key: url
-              name: jx-boot
-        - name: GIT_USER
-          valueFrom:
-            secretKeyRef:
-              key: username
-              name: jx-boot
-        - name: GIT_TOKEN
-          valueFrom:
-            secretKeyRef:
-              key: password
-              name: jx-boot
-        - name: GIT_REVISION
-          value: master
-        - name: GIT_SUB_DIR
-          value: source
-        - name: GIT_AUTHOR_EMAIL
-          value: jenkins-x@googlegroups.com
-        - name: GIT_AUTHOR_NAME
-          value: jenkins-x-labs-bot
-        - name: GIT_COMMITTER_EMAIL
-          value: jenkins-x@googlegroups.com
-        - name: GIT_COMMITTER_NAME
-          value: jenkins-x-labs-bot
-        - name: XDG_CONFIG_HOME
-          value: /workspace/xdg_config
+        - jx
         image: gcr.io/jenkinsxio/jx-boot:3.0.754
         name: git-clone
         volumeMounts:

--- a/git-operator/job.yaml
+++ b/git-operator/job.yaml
@@ -21,6 +21,9 @@ spec:
         - clone
         command:
         - jx
+        env:
+        - name: XDG_CONFIG_HOME
+          value: /workspace/xdg_config
         image: gcr.io/jenkinsxio/jx-boot:3.0.754
         name: git-clone
         volumeMounts:
@@ -32,6 +35,9 @@ spec:
         - apply
         command:
         - make
+        env:
+        - name: XDG_CONFIG_HOME
+          value: /workspace/xdg_config
         image: gcr.io/jenkinsxio/jx-boot:3.0.754
         imagePullPolicy: Always
         name: job


### PR DESCRIPTION
so that we can handle http better and reuse the git init commands configured on the operator to deal with insecure registries