### PR TITLE
fix: Add env-var for AWS_REGION

### DIFF
--- a/charts/jx3/jx-build-controller/values.yaml.gotmpl
+++ b/charts/jx3/jx-build-controller/values.yaml.gotmpl
@@ -7,3 +7,8 @@ serviceaccount:
   annotations:
     eks.amazonaws.com/role-arn: arn:aws:iam::{{ .Values.jxRequirements.cluster.project }}:role/{{ .Values.jxRequirements.cluster.clusterName }}-build-ctrl
 {{- end }}
+
+{{- if eq .Values.jxRequirements.cluster.provider "eks" }}
+env:
+  AWS_REGION: {{ .Values.jxRequirements.cluster.region }}
+{{- end }}


### PR DESCRIPTION
Although S3 buckets are global, go-cloud and most AWS SDKs need AWS_REGION to work. Reference: https://github.com/google/go-cloud/issues/1357