### PR TITLE
chore: Add annotation for workload identity in AWS

### DIFF
--- a/charts/jx3/jx-pipelines-visualizer/values.yaml.gotmpl
+++ b/charts/jx3/jx-pipelines-visualizer/values.yaml.gotmpl
@@ -26,6 +26,8 @@ serviceAccount:
   annotations:
 {{- if eq .Values.jxRequirements.cluster.provider "gke" }}
     iam.gke.io/gcp-service-account: {{ .Values.jxRequirements.cluster.clusterName }}-jxui@{{ .Values.jxRequirements.cluster.project }}.iam.gserviceaccount.com
+{{- else if eq .Values.jxRequirements.cluster.provider "eks" }}
+    eks.amazonaws.com/role-arn: arn:aws:iam::{{ .Values.jxRequirements.cluster.project }}:role/{{ .Values.jxRequirements.cluster.clusterName }}-jx-pipelines-visualizer
 {{- else }}
     installed-by: jenkins-x
 {{- end }}


### PR DESCRIPTION
`jx-pipelines-visualizer` would need this to fetch logs from S3.