### PR TITLE
fix(pipelines-visualizer): Add env-var for AWS_REGION

### DIFF
--- a/charts/jx3/jx-pipelines-visualizer/defaults.yaml
+++ b/charts/jx3/jx-pipelines-visualizer/defaults.yaml
@@ -1,2 +1,2 @@
 gitUrl: https://github.com/jenkins-x/jx-pipelines-visualizer
-version: 0.0.52
+version: 0.0.53

--- a/charts/jx3/jx-pipelines-visualizer/values.yaml.gotmpl
+++ b/charts/jx3/jx-pipelines-visualizer/values.yaml.gotmpl
@@ -22,6 +22,12 @@ ingress:
       "tls-{{ .Values.jxRequirements.ingress.domain | replace "." "-" }}-s": {}
 {{- end }}
 
+{{- if eq .Values.jxRequirements.cluster.provider "eks" }}
+pod:
+  env:
+    AWS_REGION: {{ .Values.jxRequirements.cluster.region }}
+{{- end }}
+
 serviceAccount:
   annotations:
 {{- if eq .Values.jxRequirements.cluster.provider "gke" }}


### PR DESCRIPTION
To read from log storage in AWS S3. Depends on: https://github.com/jenkins-x/jx-pipelines-visualizer/pull/41